### PR TITLE
changed links relative to git src instead of global

### DIFF
--- a/include/casm/external/Eigen
+++ b/include/casm/external/Eigen
@@ -1,1 +1,1 @@
-/Users/bpuchala/Work/codes/CASMcode_modules/CASMcode_global/submodules/eigen/Eigen
+../../../submodules/eigen/Eigen

--- a/include/casm/external/nlohmann
+++ b/include/casm/external/nlohmann
@@ -1,1 +1,1 @@
-/Users/bpuchala/Work/codes/CASMcode_modules/CASMcode_global/submodules/json/single_include/nlohmann
+../../../submodules/json/single_include/nlohmann


### PR DESCRIPTION
- `Eigen` and `nlohmann` are defined as absolute paths which makes it uninstallable